### PR TITLE
fix: Misconfigured cache

### DIFF
--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -2,9 +2,13 @@ import { ReleaseType } from "semver"
 import { workspace } from "vscode"
 
 export const getCacheLifetime = () => {
-  return workspace
-    .getConfiguration()
-    .get<number>("npm-outdated.cacheLifetime") as number
+  return (
+    Number(
+      workspace.getConfiguration().get<number>("npm-outdated.cacheLifetime")
+    ) *
+    60 *
+    1000
+  )
 }
 
 export const getLevel = () => {


### PR DESCRIPTION
_The cache system interpreted the "60" setting as "60ms" instead of "60 minutes"._

It was a huge mistake on my part, as there is virtually no working caching system anymore. This makes it difficult to apply the quick-fixes, especially if there are many packages in the project.

Please prioritize this merge.