### PR TITLE
Fix response parsing for unzipped responses

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -135,9 +135,9 @@ export const fetchLite = <T>(options: FetchLite): Promise<T | undefined> => {
     const thisReq = https.request(
       { headers, hostname, method: options.method ?? "get", path },
       (response: IncomingMessage) => {
-        const responseBuffers: Buffer[] = []
+        const responseBuffers: Uint8Array[] = []
 
-        response.on("data", (data: Buffer) => responseBuffers.push(data))
+        response.on("data", (data: Uint8Array) => responseBuffers.push(data))
         // istanbul ignore next
         response.on("error", () => resolve(undefined))
         response.on("end", () => {

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -141,12 +141,13 @@ export const fetchLite = <T>(options: FetchLite): Promise<T | undefined> => {
         // istanbul ignore next
         response.on("error", () => resolve(undefined))
         response.on("end", () => {
+          const concatenatedResponse = Buffer.concat(responseBuffers)
           if (!response.headers["content-encoding"]) {
-            return resolve(JSON.parse(responseBuffers.toString()))
+            return resolve(JSON.parse(concatenatedResponse.toString()))
           }
 
           return zlib.gunzip(
-            Buffer.concat(responseBuffers),
+            concatenatedResponse,
             (_error, contents) => {
               resolve(JSON.parse(contents.toString()))
             }


### PR DESCRIPTION
Commit 1611ba65c17411a8be0371d2130ad62b97c8748c added support for unzipped responses but forgot to concatenate the buffers before converting them to a string. This results in a corrupt JSON string if we have more than one element in the response buffers (e.g. for a large response). If we have multiple elements in the response buffers `responseBuffers.toString()` would include ',' as default concatenation character. We could also use `responseBuffers.join('')` to get the same result, but with `Buffer.concat(responseBuffers)` we can use the same object also as parameter for the gunzip method in case the response is gzipped.