### PR TITLE
Ignore deprecated versions

### DIFF
--- a/src/NPM.ts
+++ b/src/NPM.ts
@@ -9,7 +9,12 @@ import { cacheEnabled, fetchLite } from "./Utils.js"
 type PackagesVersions = Map<string, Cache<Promise<string[] | null>>>
 
 interface NPMRegistryPackage {
-  versions?: Record<string, unknown>
+  versions?: Record<string, NPMRegistryPackageVersionInfo>
+}
+
+interface NPMRegistryPackageVersionInfo {
+  version: string
+  deprecated?: string
 }
 
 // The `npm view` cache.
@@ -37,7 +42,9 @@ export const getPackageVersions = async (
       url: `https://registry.npmjs.org/${name}`,
     }).then((data) => {
       if (data?.versions) {
-        return resolve(Object.keys(data.versions))
+        const versionsWithDeprecationInfo = Object.values(data.versions)
+          .map(versionInfo => versionInfo.deprecated ? `${versionInfo.version}-deprecated` : versionInfo.version)
+        return resolve(versionsWithDeprecationInfo)
       }
 
       // Uses `npm view` as a fallback.

--- a/src/NPM.ts
+++ b/src/NPM.ts
@@ -42,9 +42,10 @@ export const getPackageVersions = async (
       url: `https://registry.npmjs.org/${name}`,
     }).then((data) => {
       if (data?.versions) {
-        const versionsWithDeprecationInfo = Object.values(data.versions)
-          .map(versionInfo => versionInfo.deprecated ? `${versionInfo.version}-deprecated` : versionInfo.version)
-        return resolve(versionsWithDeprecationInfo)
+        const versionsWithoutDeprecated = Object.values(data.versions)
+          .filter(versionInfo => versionInfo.deprecated === undefined)
+          .map(versionInfo => versionInfo.version)
+        return resolve(versionsWithoutDeprecated)
       }
 
       // Uses `npm view` as a fallback.

--- a/src/TestUtils.ts
+++ b/src/TestUtils.ts
@@ -163,8 +163,8 @@ export const vscodeSimulator = async (options: SimulatorOptions = {}) => {
           return Promise.resolve({
             versions: Object.fromEntries(
               options.packagesRepository[packageName].map((version) => [
-                version,
-                null,
+                version.replace('-deprecated', ''),
+                { version, deprecated: version.includes('-deprecated') ? '' : undefined },
               ]) as []
             ),
           })

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -381,6 +381,32 @@ describe("package diagnostics", () => {
     expect(decorations[0]).not.toContain("(attention: major update!)")
   })
 
+  it("valid dependency, latest is deprecated", async () => {
+    const { decorations, diagnostics } = await vscodeSimulator({
+      packageJson: { dependencies: { "npm-outdated": "^1.0.0" } },
+      packagesInstalled: { "npm-outdated": "1.0.1" },
+      packagesRepository: { "npm-outdated": ["1.0.0", "1.0.1", "1.0.2-deprecated"] },
+    })
+
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0]?.message).toContain("Newer version")
+    expect(diagnostics[0]?.message).toContain("1.0.1")
+    expect(decorations[0]).toContain("(already installed, just formalization)")
+  })
+
+  it("valid dependency, skip deprecated versions", async () => {
+    const { decorations, diagnostics } = await vscodeSimulator({
+      packageJson: { dependencies: { "npm-outdated": "^1.0.0" } },
+      packagesInstalled: { "npm-outdated": "1.0.1" },
+      packagesRepository: { "npm-outdated": ["1.0.0", "1.0.1", "1.0.2-deprecated", "1.0.3"] },
+    })
+
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0]?.message).toContain("Newer version")
+    expect(diagnostics[0]?.message).toContain("1.0.3")
+    expect(decorations[0]).toContain("Update available:")
+  })
+
   it("dependency name is invalid", async () => {
     const { decorations, diagnostics } = await vscodeSimulator({
       packageJson: { dependencies: { "invalid!": "^1.0.0" } },

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -264,7 +264,7 @@ describe("package diagnostics", () => {
       packageJson: { dependencies: { "npm-outdated": "^1.0.1-alpha" } },
       packagesInstalled: { "npm-outdated": "1.0.1-alpha" },
       packagesRepository: {
-        "npm-outdated": ["1.0.0", "1.0.1-alpha", "1.0.2-alpha"],
+        "npm-outdated": ["1.0.0", "1.0.1-alpha", "1.0.2-alpha", "1.0.3-deprecated"],
       },
     })
 


### PR DESCRIPTION
This pull request fixes https://github.com/mskelton/vscode-npm-outdated/issues/28.

This pull requests ensures, that package versions that are deprecated are ignored when requesting all package versions by checking if the version information from the registry contains a `deprecated` field (with some information text that we ignore, e.g. `Use @eslint/config-array instead`).

Limitation: it only works for public available packages because only then we get the needed information about the deprecated status from the registry.